### PR TITLE
Add a "more" html comment to make automatic teaser texts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const markdownItAttrs = require( "markdown-it-attrs" );
 const markdownItTocDoneRight = require( "markdown-it-toc-done-right" );
 const prism = require('markdown-it-prism');
 const filters = require('./utils/filters.js')
+const striptags = require("striptags");
 
 module.exports = function( eleventyConfig ) {
 
@@ -49,7 +50,19 @@ module.exports = function( eleventyConfig ) {
           inputContent.indexOf('\n')
         )
       }
-    })
+      const content = post.template.inputContent;
+      // The start and end separators to try and match to extract the excerpt
+      const separatorsList = [
+        { start: '\n\n', end: '<!-- more -->' },
+        { start: '\n\n', end: '\n\n' }
+      ];
+      separatorsList.some(separators => {
+        const startPosition = content.indexOf(separators.start);
+        const endPosition = content.indexOf(separators.end);
+        post.excerpt = content.substring(startPosition + separators.start.length, endPosition).trim();
+        return true;
+      });
+    });
     return posts;
   });
 

--- a/_src/_partials/postslist.njk
+++ b/_src/_partials/postslist.njk
@@ -2,12 +2,13 @@
   {% if not post.data.tags.includes('index') %}
   <article class="post">
     <header>
-      <h3><a href="{{ post.url | url }}" class="postlist-link">{{ post | getPageTitle }}</a></h3>
+      <h3><a href="{{ post.url | url }}">{{ post | getPageTitle }}</a></h3>
       <!--
       We won't have postdates, as the markdown lacks them and filedate is unusable
       <time class="postlist-date" datetime="{{ post.date }}">{{ post.date | readableDate }}</time>
       -->
     </header>
+    <div class="post-content">{{ post | getExcerpt }}</div>
   </article>
   {% endif %}
 {% endfor %}

--- a/blog/document-outline.md
+++ b/blog/document-outline.md
@@ -1,7 +1,7 @@
 # Small Wins: Improving our Document Outline
 
 The document outline is a way to overview and navigate a web page. It provides a high-level overview on a page, and is mostly used by screen readers to provide meaning and allow navigation for people who cannot access the visual representation of the page. At ZEIT Online we actively shape this outline, in order to improve the accessibility of our news website. This post shows some practical examples of that process.
-
+<!-- more -->
 ## What is the document outline?
 
 The document outline represents the logical or semantical structure of an HTML document. This is a little difficult because there are two concepts: hierarchy of headlines `h1` to `h6` and the nested structure of `sections` and `divs`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,6 +4124,11 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "markdown-it-attrs": "^3.0.3",
     "markdown-it-container": "^3.0.0",
     "markdown-it-prism": "^2.1.3",
-    "markdown-it-toc-done-right": "^4.2.0"
+    "markdown-it-toc-done-right": "^4.2.0",
+    "striptags": "^3.1.1"
   }
 }

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -8,6 +8,8 @@ module.exports = {
    */
   getPageTitle: (post) => post.customTitle,
 
+  getExcerpt: (post) => post.excerpt,
+
   generateEleventyNavigation: (posts) => {
     var pages = [];
     posts.forEach(post => {


### PR DESCRIPTION
Durch das abteilen eines oder mehrerer Textteile im Markdown, durch ein

```html
<!-- more -->
```

wird der Content davor ausgelesen und als `excerpt` in der Collection zur Verfügung gestellt. Dies kann dann als Teasertext auf der inzwischen automagisch erstellten Blogindex-Seite ausgegeben werden, siehe Beispiel.